### PR TITLE
Add bundler hint to ignore fs module on browser environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copc",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copc",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged"
     }
+  },
+  "browser": {
+      "fs": false
   }
 }


### PR DESCRIPTION
As described in #6, bundlers (e.g. webpack) are not smart enough to prune the lazy-loaded `fs` module on browser environments. This PR adds additional hint in `package.json` to ignore this module.

P.S.: I tested it with `copc-umd` without the ` resolve: { alias: { fs: false } }`